### PR TITLE
(fix buat tombol baru) dan (fungsi get_pagination_data di pisah ke DataTableTrait)

### DIFF
--- a/app/Http/Livewire/Table/DataTableTrait.php
+++ b/app/Http/Livewire/Table/DataTableTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Livewire\Table;
+
+
+trait DataTableTrait {
+    
+    public function get_pagination_data ()
+    {
+        switch ($this->name) {
+            case 'user':
+                $users = $this->model::search($this->search)
+                    ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
+                    ->paginate($this->perPage);
+
+                return [
+                    "view" => 'livewire.table.user',
+                    "users" => $users,
+                    "data" => array_to_object([
+                        'href' => [
+                            'create_new' => route('user.new'),
+                            'create_new_text' => 'Buat User Baru',
+                            'export' => '#',
+                            'export_text' => 'Export'
+                        ]
+                    ])
+                ];
+                break;
+
+            default:
+                # code...
+                break;
+        }
+    }
+}

--- a/app/Http/Livewire/Table/Main.php
+++ b/app/Http/Livewire/Table/Main.php
@@ -7,7 +7,7 @@ use Livewire\WithPagination;
 
 class Main extends Component
 {
-    use WithPagination;
+    use WithPagination, DataTableTrait;
 
     public $model;
     public $name;
@@ -28,34 +28,6 @@ class Main extends Component
         }
 
         $this->sortField = $field;
-    }
-
-    public function get_pagination_data ()
-    {
-        switch ($this->name) {
-            case 'user':
-                $users = $this->model::search($this->search)
-                    ->orderBy($this->sortField, $this->sortAsc ? 'asc' : 'desc')
-                    ->paginate($this->perPage);
-
-                return [
-                    "view" => 'livewire.table.user',
-                    "users" => $users,
-                    "data" => array_to_object([
-                        'href' => [
-                            'create_new' => route('user.new'),
-                            'create_new_text' => 'Buat User Baru',
-                            'export' => '#',
-                            'export_text' => 'Export'
-                        ]
-                    ])
-                ];
-                break;
-
-            default:
-                # code...
-                break;
-        }
     }
 
     public function delete_item ($id)

--- a/app/Http/Livewire/Table/Main.php
+++ b/app/Http/Livewire/Table/Main.php
@@ -4,10 +4,11 @@ namespace App\Http\Livewire\Table;
 
 use Livewire\Component;
 use Livewire\WithPagination;
+use App\Traits\WithDataTable;
 
 class Main extends Component
 {
-    use WithPagination, DataTableTrait;
+    use WithPagination, WithDataTable;
 
     public $model;
     public $name;

--- a/app/Traits/WithDataTable.php
+++ b/app/Traits/WithDataTable.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace App\Http\Livewire\Table;
+namespace App\Traits;
 
 
-trait DataTableTrait {
+trait WithDataTable {
     
     public function get_pagination_data ()
     {

--- a/resources/views/components/data-table.blade.php
+++ b/resources/views/components/data-table.blade.php
@@ -1,7 +1,7 @@
 <div class="bg-gray-100 text-gray-900 tracking-wider leading-normal">
     <div class="p-8 pt-4 mt-2 bg-white" x-data="window.__controller.dataTableMainController()" x-init="setCallback();">
         <div class="flex pb-4 -ml-3">
-            <a href="{{ $data->href->create_new }}" target="_blank" class="-ml- btn btn-primary shadow-none">
+            <a href="{{ $data->href->create_new }}"  class="-ml- btn btn-primary shadow-none">
                 <span class="fas fa-plus"></span> {{ $data->href->create_new_text }}
             </a>
             <a href="{{ $data->href->export }}" class="ml-2 btn btn-success shadow-none">


### PR DESCRIPTION
fix buat tombol baru : 
        menghapus (target="_blank") untuk menghilangkan efek buat tab baru saat tombol buat user baru di tekan.

fungsi get_pagination_data di pisah ke DataTableTrait:
       update data tabel baru bisa di lakukan di file DataTableTrait, sehingga kode file \app\Http\Livewire\Table\Main.php tidak bertambah banyak. Sekaligus memisahkan fungsi logic dan fungsi data. 